### PR TITLE
delete api issue

### DIFF
--- a/src/LonghornOpen/CanvasApi/CanvasApiClient.php
+++ b/src/LonghornOpen/CanvasApi/CanvasApiClient.php
@@ -141,7 +141,7 @@ class CanvasApiClient
      * @return object|null
      * @throws GuzzleException
      */
-    public function delete($api_url, $data)
+    public function delete($api_url, $data = [])
     {
         if (empty($data)) {
             $data = [];


### PR DESCRIPTION
This is a fix of a change where it made the data parameter mandatory by accident, now it's set as an empty array by default. This should insure backwards compatibility. 